### PR TITLE
feat: add firewall, loadbalancer, network, and objectstore resources

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -1,0 +1,210 @@
+name: Manual Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      resource:
+        description: 'Resource to test (network, firewall, loadbalancer, objectstorage, or all)'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - network
+          - firewall
+          - loadbalancer
+          - objectstorage
+
+jobs:
+  build:
+    name: Build Provider
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build provider
+        run: go build -o terraform-provider-idcloudhost
+
+      - name: Upload provider binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-provider-idcloudhost
+          path: terraform-provider-idcloudhost
+          retention-days: 1
+
+  test-network:
+    name: Test Network Resource
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.resource == 'network' || github.event.inputs.resource == 'all' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.6.0'
+
+      - name: Download provider binary
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-provider-idcloudhost
+
+      - name: Make provider executable
+        run: chmod +x terraform-provider-idcloudhost
+
+      - name: Test Network Resource
+        working-directory: examples/network
+        env:
+          IDCLOUDHOST_AUTH_TOKEN: ${{ secrets.IDCLOUDHOST_AUTH_TOKEN }}
+        run: |
+          terraform init
+          terraform plan
+          terraform apply -auto-approve
+          terraform show
+          terraform destroy -auto-approve
+
+  test-firewall:
+    name: Test Firewall Resource
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.resource == 'firewall' || github.event.inputs.resource == 'all' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.6.0'
+
+      - name: Download provider binary
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-provider-idcloudhost
+
+      - name: Make provider executable
+        run: chmod +x terraform-provider-idcloudhost
+
+      - name: Test Firewall Resource
+        working-directory: examples/firewall
+        env:
+          IDCLOUDHOST_AUTH_TOKEN: ${{ secrets.IDCLOUDHOST_AUTH_TOKEN }}
+        run: |
+          terraform init
+          terraform plan
+          terraform apply -auto-approve
+          terraform show
+          terraform destroy -auto-approve
+
+  test-loadbalancer:
+    name: Test LoadBalancer Resource
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.resource == 'loadbalancer' || github.event.inputs.resource == 'all' }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.6.0'
+
+      - name: Download provider binary
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-provider-idcloudhost
+
+      - name: Make provider executable
+        run: chmod +x terraform-provider-idcloudhost
+
+      - name: Test LoadBalancer Resource
+        working-directory: examples/loadbalancer
+        env:
+          IDCLOUDHOST_AUTH_TOKEN: ${{ secrets.IDCLOUDHOST_AUTH_TOKEN }}
+        run: |
+          terraform init
+          terraform plan
+          terraform apply -auto-approve
+          terraform show
+          terraform destroy -auto-approve
+
+  test-objectstorage:
+    name: Test ObjectStorage Resource
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.resource == 'objectstorage' || github.event.inputs.resource == 'all' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.6.0'
+
+      - name: Download provider binary
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-provider-idcloudhost
+
+      - name: Make provider executable
+        run: chmod +x terraform-provider-idcloudhost
+
+      - name: Update bucket names with timestamp
+        working-directory: examples/objectstorage
+        run: |
+          TIMESTAMP=$(date +%s)
+          sed -i "s/my-app-data-bucket/my-app-data-bucket-${TIMESTAMP}/g" main.tf
+          sed -i "s/my-backup-bucket/my-backup-bucket-${TIMESTAMP}/g" main.tf
+          sed -i "s/my-static-assets/my-static-assets-${TIMESTAMP}/g" main.tf
+
+      - name: Test ObjectStorage Resource
+        working-directory: examples/objectstorage
+        env:
+          IDCLOUDHOST_AUTH_TOKEN: ${{ secrets.IDCLOUDHOST_AUTH_TOKEN }}
+        run: |
+          terraform init
+          terraform plan
+          terraform apply -auto-approve
+          terraform show
+          terraform destroy -auto-approve
+
+  summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [test-network, test-firewall, test-loadbalancer, test-objectstorage]
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Resource | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Network | ${{ needs.test-network.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Firewall | ${{ needs.test-firewall.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| LoadBalancer | ${{ needs.test-loadbalancer.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ObjectStorage | ${{ needs.test-objectstorage.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ vendor/
 
 # Terraform files
 examples/.terraform*
+examples/**/.terraform*
 examples/*.tfstate*
+examples/**/*.tfstate*
 examples/*.log

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,316 @@
+terraform {
+  required_providers {
+    idcloudhost = {
+      version = "0.2.0"
+      source  = "github.com/bapung/idcloudhost"
+    }
+  }
+}
+
+provider "idcloudhost" {
+  # auth_token is read from IDCLOUDHOST_AUTH_TOKEN environment variable
+  # region defaults to "jkt01"
+}
+
+# Variables for configuration
+locals {
+  billing_account_id = 1200177265  # Replace with your billing account ID
+  project_name       = "example-app"
+}
+
+# ============================================================================
+# Network Resources
+# ============================================================================
+
+# Create a private network for the application
+resource "idcloudhost_network" "app_network" {
+  name    = "${local.project_name}-network"
+  default = false
+}
+
+# ============================================================================
+# Firewall Resources
+# ============================================================================
+
+# Create a firewall for web servers
+resource "idcloudhost_firewall" "web_firewall" {
+  display_name       = "${local.project_name}-web-firewall"
+  billing_account_id = local.billing_account_id
+  description        = "Firewall rules for web servers"
+
+  # Allow HTTP
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 80
+    port_end           = 80
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow HTTP"
+  }
+
+  # Allow HTTPS
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 443
+    port_end           = 443
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow HTTPS"
+  }
+
+  # Allow SSH from specific CIDR
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 22
+    port_end           = 22
+    endpoint_spec_type = "cidr"
+    endpoint_spec      = ["0.0.0.0/0"]  # Change to your IP range
+    description        = "Allow SSH"
+  }
+
+  # Allow all outbound
+  rules {
+    direction          = "outbound"
+    protocol           = "any"
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow all outbound"
+  }
+}
+
+# Create a firewall for database servers
+resource "idcloudhost_firewall" "db_firewall" {
+  display_name       = "${local.project_name}-db-firewall"
+  billing_account_id = local.billing_account_id
+  description        = "Firewall rules for database servers"
+
+  # Allow PostgreSQL from app network
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 5432
+    port_end           = 5432
+    endpoint_spec_type = "cidr"
+    endpoint_spec      = ["10.0.0.0/8"]
+    description        = "Allow PostgreSQL"
+  }
+
+  # Allow SSH
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 22
+    port_end           = 22
+    endpoint_spec_type = "cidr"
+    endpoint_spec      = ["0.0.0.0/0"]  # Change to your IP range
+    description        = "Allow SSH"
+  }
+
+  # Allow all outbound
+  rules {
+    direction          = "outbound"
+    protocol           = "any"
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow all outbound"
+  }
+}
+
+# ============================================================================
+# Virtual Machine Resources
+# ============================================================================
+
+# Create web server VMs
+resource "idcloudhost_vm" "web_server_1" {
+  name               = "${local.project_name}-web-1"
+  os_name            = "ubuntu"
+  os_version         = "20.04"
+  disks              = 20
+  vcpu               = 2
+  memory             = 2048
+  username           = "ubuntu"
+  initial_password   = "ChangeMe123!"  # Change this!
+  billing_account_id = local.billing_account_id
+  backup             = false
+}
+
+resource "idcloudhost_vm" "web_server_2" {
+  name               = "${local.project_name}-web-2"
+  os_name            = "ubuntu"
+  os_version         = "20.04"
+  disks              = 20
+  vcpu               = 2
+  memory             = 2048
+  username           = "ubuntu"
+  initial_password   = "ChangeMe123!"  # Change this!
+  billing_account_id = local.billing_account_id
+  backup             = false
+}
+
+# Create database server VM
+resource "idcloudhost_vm" "db_server" {
+  name               = "${local.project_name}-db"
+  os_name            = "ubuntu"
+  os_version         = "20.04"
+  disks              = 40
+  vcpu               = 4
+  memory             = 4096
+  username           = "ubuntu"
+  initial_password   = "ChangeMe123!"  # Change this!
+  billing_account_id = local.billing_account_id
+  backup             = true
+}
+
+# ============================================================================
+# Load Balancer Resources
+# ============================================================================
+
+# Create a load balancer for web servers
+resource "idcloudhost_loadbalancer" "web_lb" {
+  display_name       = "${local.project_name}-web-lb"
+  billing_account_id = local.billing_account_id
+  network_uuid       = idcloudhost_network.app_network.uuid
+  reserve_public_ip  = true
+
+  # Add web servers as targets
+  targets {
+    target_type = "vm"
+    target_uuid = idcloudhost_vm.web_server_1.uuid
+  }
+
+  targets {
+    target_type = "vm"
+    target_uuid = idcloudhost_vm.web_server_2.uuid
+  }
+
+  # HTTP forwarding rule
+  forwarding_rules {
+    source_port = 80
+    target_port = 8080
+  }
+
+  # HTTPS forwarding rule
+  forwarding_rules {
+    source_port = 443
+    target_port = 8443
+  }
+}
+
+# ============================================================================
+# Object Storage Resources
+# ============================================================================
+
+# Create object storage bucket for application data
+resource "idcloudhost_objectstorage" "app_data" {
+  name               = "${local.project_name}-app-data"
+  billing_account_id = local.billing_account_id
+}
+
+# Create object storage bucket for backups
+resource "idcloudhost_objectstorage" "backups" {
+  name               = "${local.project_name}-backups"
+  billing_account_id = local.billing_account_id
+}
+
+# Create object storage bucket for static assets
+resource "idcloudhost_objectstorage" "static_assets" {
+  name               = "${local.project_name}-static"
+  billing_account_id = local.billing_account_id
+}
+
+# ============================================================================
+# Floating IP Resources
+# ============================================================================
+
+# Create a floating IP for the database server
+resource "idcloudhost_floating_ip" "db_floating_ip" {
+  name               = "${local.project_name}-db-fip"
+  billing_account_id = local.billing_account_id
+}
+
+# ============================================================================
+# Outputs
+# ============================================================================
+
+output "network_uuid" {
+  value       = idcloudhost_network.app_network.uuid
+  description = "The UUID of the application network"
+}
+
+output "web_firewall_uuid" {
+  value       = idcloudhost_firewall.web_firewall.uuid
+  description = "The UUID of the web firewall"
+}
+
+output "db_firewall_uuid" {
+  value       = idcloudhost_firewall.db_firewall.uuid
+  description = "The UUID of the database firewall"
+}
+
+output "web_server_1_uuid" {
+  value       = idcloudhost_vm.web_server_1.uuid
+  description = "The UUID of web server 1"
+}
+
+output "web_server_1_private_ip" {
+  value       = idcloudhost_vm.web_server_1.private_ipv4
+  description = "The private IP of web server 1"
+}
+
+output "web_server_2_uuid" {
+  value       = idcloudhost_vm.web_server_2.uuid
+  description = "The UUID of web server 2"
+}
+
+output "web_server_2_private_ip" {
+  value       = idcloudhost_vm.web_server_2.private_ipv4
+  description = "The private IP of web server 2"
+}
+
+output "db_server_uuid" {
+  value       = idcloudhost_vm.db_server.uuid
+  description = "The UUID of the database server"
+}
+
+output "db_server_private_ip" {
+  value       = idcloudhost_vm.db_server.private_ipv4
+  description = "The private IP of the database server"
+}
+
+output "load_balancer_uuid" {
+  value       = idcloudhost_loadbalancer.web_lb.uuid
+  description = "The UUID of the load balancer"
+}
+
+output "load_balancer_private_address" {
+  value       = idcloudhost_loadbalancer.web_lb.private_address
+  description = "The private IP address of the load balancer"
+}
+
+output "load_balancer_targets" {
+  value       = idcloudhost_loadbalancer.web_lb.targets
+  description = "The targets of the load balancer"
+}
+
+output "app_data_bucket" {
+  value       = idcloudhost_objectstorage.app_data.name
+  description = "The name of the app data bucket"
+}
+
+output "backups_bucket" {
+  value       = idcloudhost_objectstorage.backups.name
+  description = "The name of the backups bucket"
+}
+
+output "static_assets_bucket" {
+  value       = idcloudhost_objectstorage.static_assets.name
+  description = "The name of the static assets bucket"
+}
+
+output "db_floating_ip_address" {
+  value       = idcloudhost_floating_ip.db_floating_ip.address
+  description = "The floating IP address for the database server"
+}

--- a/examples/firewall/main.tf
+++ b/examples/firewall/main.tf
@@ -1,0 +1,116 @@
+terraform {
+  required_providers {
+    idcloudhost = {
+      version = "0.2.0"
+      source  = "github.com/bapung/idcloudhost"
+    }
+  }
+}
+
+provider "idcloudhost" {
+  # auth_token is read from IDCLOUDHOST_AUTH_TOKEN environment variable
+  # region defaults to "jkt01"
+}
+
+# Create a firewall with multiple rules
+resource "idcloudhost_firewall" "web_firewall" {
+  display_name        = "web-server-firewall"
+  billing_account_id  = 1200132376  # Replace with your billing account ID
+  description         = "Firewall for web servers"
+
+  # Allow HTTP inbound traffic
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 80
+    port_end           = 80
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow HTTP traffic"
+  }
+
+  # Allow HTTPS inbound traffic
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 443
+    port_end           = 443
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow HTTPS traffic"
+  }
+
+  # Allow SSH from specific CIDR
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 22
+    port_end           = 22
+    endpoint_spec_type = "ip_prefixes"
+    endpoint_spec      = ["203.0.113.0/24"]
+    description        = "Allow SSH from office network"
+  }
+
+  # Allow all outbound traffic
+  rules {
+    direction          = "outbound"
+    protocol           = "any"
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow all outbound traffic"
+  }
+}
+
+# Create a database firewall
+resource "idcloudhost_firewall" "database_firewall" {
+  display_name        = "database-firewall"
+  billing_account_id  = 1200132376  # Replace with your billing account ID
+  description         = "Firewall for database servers"
+
+  # Allow PostgreSQL from specific CIDR
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 5432
+    port_end           = 5432
+    endpoint_spec_type = "ip_prefixes"
+    endpoint_spec      = ["10.0.1.0/24"]
+    description        = "Allow PostgreSQL from app network"
+  }
+
+  # Allow MySQL from specific CIDR
+  rules {
+    direction          = "inbound"
+    protocol           = "tcp"
+    port_start         = 3306
+    port_end           = 3306
+    endpoint_spec_type = "ip_prefixes"
+    endpoint_spec      = ["10.0.1.0/24"]
+    description        = "Allow MySQL from app network"
+  }
+
+  # Allow ICMP ping
+  rules {
+    direction          = "inbound"
+    protocol           = "icmp"
+    endpoint_spec_type = "any"
+    endpoint_spec      = []
+    description        = "Allow ICMP ping"
+  }
+}
+
+# Output firewall details
+output "web_firewall_uuid" {
+  value       = idcloudhost_firewall.web_firewall.uuid
+  description = "The UUID of the web firewall"
+}
+
+output "web_firewall_id" {
+  value       = idcloudhost_firewall.web_firewall.id
+  description = "The ID of the web firewall"
+}
+
+output "database_firewall_uuid" {
+  value       = idcloudhost_firewall.database_firewall.uuid
+  description = "The UUID of the database firewall"
+}

--- a/examples/loadbalancer/main.tf
+++ b/examples/loadbalancer/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    idcloudhost = {
+      version = "0.2.0"
+      source  = "github.com/bapung/idcloudhost"
+    }
+  }
+}
+
+provider "idcloudhost" {
+  # auth_token is read from IDCLOUDHOST_AUTH_TOKEN environment variable
+  # region defaults to "jkt01"
+}
+
+# Create a network for the load balancer
+resource "idcloudhost_network" "lb_network" {
+  name = "loadbalancer-network"
+}
+
+# Create VMs to use as load balancer targets
+resource "idcloudhost_vm" "web_server_1" {
+  name               = "web-server-1"
+  os_name            = "ubuntu"
+  os_version         = "20.04"
+  disks              = 20
+  vcpu               = 2
+  memory             = 2048
+  username           = "ubuntu"
+  initial_password   = "SecurePassword123!"
+  billing_account_id = 1200132376  # Replace with your billing account ID
+  backup             = false
+}
+
+resource "idcloudhost_vm" "web_server_2" {
+  name               = "web-server-2"
+  os_name            = "ubuntu"
+  os_version         = "20.04"
+  disks              = 20
+  vcpu               = 2
+  memory             = 2048
+  username           = "ubuntu"
+  initial_password   = "SecurePassword123!"
+  billing_account_id = 1200132376  # Replace with your billing account ID
+  backup             = false
+}
+
+# Create a load balancer with targets and forwarding rules
+resource "idcloudhost_loadbalancer" "web_lb" {
+  display_name        = "web-load-balancer"
+  billing_account_id  = 1200132376  # Replace with your billing account ID
+  network_uuid        = idcloudhost_network.lb_network.uuid
+  reserve_public_ip   = true
+
+  # Add VM targets
+  targets {
+    target_type = "vm"
+    target_uuid = idcloudhost_vm.web_server_1.uuid
+  }
+
+  targets {
+    target_type = "vm"
+    target_uuid = idcloudhost_vm.web_server_2.uuid
+  }
+
+  # HTTP forwarding rule
+  forwarding_rules {
+    source_port = 80
+    target_port = 80
+  }
+
+  # HTTPS forwarding rule
+  forwarding_rules {
+    source_port = 443
+    target_port = 443
+  }
+}
+
+# Create a simple load balancer without initial targets
+resource "idcloudhost_loadbalancer" "simple_lb" {
+  display_name        = "simple-load-balancer"
+  billing_account_id  = 1200132376  # Replace with your billing account ID
+  network_uuid        = idcloudhost_network.lb_network.uuid
+  reserve_public_ip   = false
+}
+
+# Output load balancer details
+output "web_lb_uuid" {
+  value       = idcloudhost_loadbalancer.web_lb.uuid
+  description = "The UUID of the web load balancer"
+}
+
+output "web_lb_private_address" {
+  value       = idcloudhost_loadbalancer.web_lb.private_address
+  description = "The private IP address of the web load balancer"
+}
+
+output "web_lb_targets" {
+  value       = idcloudhost_loadbalancer.web_lb.targets
+  description = "The targets attached to the web load balancer"
+}
+
+output "web_lb_forwarding_rules" {
+  value       = idcloudhost_loadbalancer.web_lb.forwarding_rules
+  description = "The forwarding rules of the web load balancer"
+}
+
+output "simple_lb_uuid" {
+  value       = idcloudhost_loadbalancer.simple_lb.uuid
+  description = "The UUID of the simple load balancer"
+}

--- a/examples/network/main.tf
+++ b/examples/network/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    idcloudhost = {
+      version = "0.2.0"
+      source  = "github.com/bapung/idcloudhost"
+    }
+  }
+}
+
+provider "idcloudhost" {
+  # auth_token is read from IDCLOUDHOST_AUTH_TOKEN environment variable
+  # region defaults to "jkt01"
+}
+
+# Create a private network
+resource "idcloudhost_network" "example_network" {
+  name    = "my-private-network"
+  default = false
+}
+
+# Create a network and set it as default
+resource "idcloudhost_network" "default_network" {
+  name    = "my-default-network"
+  default = true
+}
+
+# Output network details
+output "example_network_uuid" {
+  value       = idcloudhost_network.example_network.uuid
+  description = "The UUID of the example network"
+}
+
+output "example_network_id" {
+  value       = idcloudhost_network.example_network.id
+  description = "The ID of the example network"
+}
+
+output "default_network_uuid" {
+  value       = idcloudhost_network.default_network.uuid
+  description = "The UUID of the default network"
+}

--- a/examples/objectstorage/main.tf
+++ b/examples/objectstorage/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    idcloudhost = {
+      version = "0.2.0"
+      source  = "github.com/bapung/idcloudhost"
+    }
+  }
+}
+
+provider "idcloudhost" {
+  # auth_token is read from IDCLOUDHOST_AUTH_TOKEN environment variable
+  # region defaults to "jkt01"
+}
+
+# Create an object storage bucket for application data
+resource "idcloudhost_objectstorage" "app_bucket" {
+  name               = "my-app-data-bucket"
+  billing_account_id = 1200132376  # Replace with your billing account ID
+}
+
+# Create an object storage bucket for backups
+resource "idcloudhost_objectstorage" "backup_bucket" {
+  name               = "my-backup-bucket"
+  billing_account_id = 1200132376  # Replace with your billing account ID
+}
+
+# Create an object storage bucket for static assets
+resource "idcloudhost_objectstorage" "static_assets_bucket" {
+  name               = "my-static-assets"
+  billing_account_id = 1200132376  # Replace with your billing account ID
+}
+
+# Output bucket details
+output "app_bucket_name" {
+  value       = idcloudhost_objectstorage.app_bucket.name
+  description = "The name of the application data bucket"
+}
+
+output "app_bucket_owner" {
+  value       = idcloudhost_objectstorage.app_bucket.owner
+  description = "The owner of the application data bucket"
+}
+
+output "app_bucket_size" {
+  value       = idcloudhost_objectstorage.app_bucket.size_bytes
+  description = "The size of the application data bucket in bytes"
+}
+
+output "backup_bucket_name" {
+  value       = idcloudhost_objectstorage.backup_bucket.name
+  description = "The name of the backup bucket"
+}
+
+output "static_assets_bucket_name" {
+  value       = idcloudhost_objectstorage.static_assets_bucket.name
+  description = "The name of the static assets bucket"
+}
+
+output "static_assets_num_objects" {
+  value       = idcloudhost_objectstorage.static_assets_bucket.num_objects
+  description = "The number of objects in the static assets bucket"
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bapung/terraform-provider-idcloudhost
 go 1.19
 
 require (
-	github.com/bapung/idcloudhost-go-client-library v1.0.5
+	github.com/bapung/idcloudhost-go-client-library v1.1.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 )
 
@@ -35,7 +35,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/bapung/idcloudhost-go-client-library v1.0.5 h1:8ns94I6Sa9jKH0FWhWfcNw+f4y0408zMWColoXAnN6k=
-github.com/bapung/idcloudhost-go-client-library v1.0.5/go.mod h1:AhWLwBPvdjd+I/Z+gzDbQGw6Vhu3IjvC/efuf9pzZgs=
+github.com/bapung/idcloudhost-go-client-library v1.1.0 h1:8hSpNz7gxDp6xQ1a9kVIsAz7oHtDBEi+fHV5wmLttTA=
+github.com/bapung/idcloudhost-go-client-library v1.1.0/go.mod h1:uOKjDEjRuX0ysz/wwJMHJWCJt9jSQ5UKraGhsp7PtdY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -128,15 +128,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/idcloudhost/provider.go
+++ b/idcloudhost/provider.go
@@ -24,9 +24,13 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"idcloudhost_vm":          resourceVirtualMachine(),
-			"idcloudhost_vm_disks":    resourceDisk(),
-			"idcloudhost_floating_ip": resourceFloatingIP(),
+			"idcloudhost_vm":            resourceVirtualMachine(),
+			"idcloudhost_vm_disks":      resourceDisk(),
+			"idcloudhost_floating_ip":   resourceFloatingIP(),
+			"idcloudhost_network":       resourceNetwork(),
+			"idcloudhost_firewall":      resourceFirewall(),
+			"idcloudhost_loadbalancer":  resourceLoadBalancer(),
+			"idcloudhost_objectstorage": resourceObjectStorage(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"idcloudhost_vms": dataSourceVirtualMachine(),

--- a/idcloudhost/resource_firewall.go
+++ b/idcloudhost/resource_firewall.go
@@ -1,0 +1,346 @@
+package idcloudhost
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	idcloudhostAPI "github.com/bapung/idcloudhost-go-client-library/idcloudhost/api"
+	idcloudhostFirewall "github.com/bapung/idcloudhost-go-client-library/idcloudhost/firewall"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceFirewall() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFirewallCreate,
+		ReadContext:   resourceFirewallRead,
+		UpdateContext: resourceFirewallUpdate,
+		DeleteContext: resourceFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"billing_account_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"direction": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								v := val.(string)
+								if v != "inbound" && v != "outbound" {
+									errs = append(errs, fmt.Errorf("%q must be either 'inbound' or 'outbound', got: %s", key, v))
+								}
+								return
+							},
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								v := val.(string)
+								if v != "tcp" && v != "udp" && v != "icmp" && v != "any" {
+									errs = append(errs, fmt.Errorf("%q must be one of 'tcp', 'udp', 'icmp', or 'any', got: %s", key, v))
+								}
+								return
+							},
+						},
+						"port_start": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"port_end": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"endpoint_spec_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								v := val.(string)
+								if v != "any" && v != "ip_prefixes" {
+									errs = append(errs, fmt.Errorf("%q must be one of 'any', or 'ip_prefixes', got: %s", key, v))
+								}
+								return
+							},
+						},
+						"endpoint_spec": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	firewall := &idcloudhostFirewall.Firewall{
+		DisplayName:      d.Get("display_name").(string),
+		BillingAccountID: d.Get("billing_account_id").(int),
+		Description:      d.Get("description").(string),
+		Rules:            expandFirewallRules(d.Get("rules").([]interface{})),
+	}
+
+	firewallApi := c.Firewall
+	if err := firewallApi.CreateFirewall(firewall); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create firewall",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId(firewallApi.Firewall.UUID)
+
+	resourceFirewallRead(ctx, d, m)
+
+	return diags
+}
+
+func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	// Get all firewalls and find the one we're looking for
+	firewallApi := c.Firewall
+	if err := firewallApi.ListFirewalls(); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to list firewalls",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	// Find the firewall with matching UUID
+	var foundFirewall *idcloudhostFirewall.Firewall
+	for _, fw := range firewallApi.Firewalls {
+		if fw.UUID == uuid {
+			foundFirewall = &fw
+			break
+		}
+	}
+
+	if foundFirewall == nil {
+		d.SetId("")
+		return diags
+	}
+
+	if err := setFirewallResource(d, foundFirewall); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to set firewall resource",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	return diags
+}
+
+func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	if d.HasChange("rules") {
+		firewall := &idcloudhostFirewall.Firewall{
+			Rules: expandFirewallRules(d.Get("rules").([]interface{})),
+		}
+
+		firewallApi := c.Firewall
+		if err := firewallApi.UpdateFirewall(uuid, firewall); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to update firewall",
+				Detail:   fmt.Sprint(err),
+			})
+			return diags
+		}
+	}
+
+	return resourceFirewallRead(ctx, d, m)
+}
+
+func resourceFirewallDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	firewallApi := c.Firewall
+	if err := firewallApi.DeleteFirewall(uuid); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to delete firewall",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId("")
+
+	return diags
+}
+
+func expandFirewallRules(rules []interface{}) []idcloudhostFirewall.FirewallRule {
+	if len(rules) == 0 {
+		return []idcloudhostFirewall.FirewallRule{}
+	}
+
+	firewallRules := make([]idcloudhostFirewall.FirewallRule, len(rules))
+
+	for i, rule := range rules {
+		ruleMap := rule.(map[string]interface{})
+
+		firewallRule := idcloudhostFirewall.FirewallRule{
+			Direction:        ruleMap["direction"].(string),
+			Protocol:         ruleMap["protocol"].(string),
+			EndpointSpecType: ruleMap["endpoint_spec_type"].(string),
+		}
+
+		if v, ok := ruleMap["uuid"].(string); ok && v != "" {
+			firewallRule.UUID = v
+		}
+
+		if v, ok := ruleMap["port_start"].(int); ok && v > 0 {
+			firewallRule.PortStart = v
+		}
+
+		if v, ok := ruleMap["port_end"].(int); ok && v > 0 {
+			firewallRule.PortEnd = v
+		}
+
+		if v, ok := ruleMap["description"].(string); ok {
+			firewallRule.Description = v
+		}
+
+		if v, ok := ruleMap["endpoint_spec"].([]interface{}); ok && len(v) > 0 {
+			endpointSpec := make([]string, len(v))
+			for j, spec := range v {
+				endpointSpec[j] = spec.(string)
+			}
+			firewallRule.EndpointSpec = endpointSpec
+		} else {
+			firewallRule.EndpointSpec = []string{}
+		}
+
+		firewallRules[i] = firewallRule
+	}
+
+	return firewallRules
+}
+
+func flattenFirewallRules(rules []idcloudhostFirewall.FirewallRule) []interface{} {
+	if len(rules) == 0 {
+		return []interface{}{}
+	}
+
+	flattenedRules := make([]interface{}, len(rules))
+
+	for i, rule := range rules {
+		ruleMap := map[string]interface{}{
+			"uuid":               rule.UUID,
+			"direction":          rule.Direction,
+			"protocol":           rule.Protocol,
+			"port_start":         rule.PortStart,
+			"port_end":           rule.PortEnd,
+			"endpoint_spec_type": rule.EndpointSpecType,
+			"endpoint_spec":      rule.EndpointSpec,
+			"description":        rule.Description,
+		}
+		flattenedRules[i] = ruleMap
+	}
+
+	return flattenedRules
+}
+
+func setFirewallResource(d *schema.ResourceData, firewall *idcloudhostFirewall.Firewall) error {
+	if err := d.Set("id", strconv.Itoa(firewall.ID)); err != nil {
+		return err
+	}
+	if err := d.Set("display_name", firewall.DisplayName); err != nil {
+		return err
+	}
+	if err := d.Set("uuid", firewall.UUID); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", firewall.UserID); err != nil {
+		return err
+	}
+	if err := d.Set("billing_account_id", firewall.BillingAccountID); err != nil {
+		return err
+	}
+	if err := d.Set("description", firewall.Description); err != nil {
+		return err
+	}
+	if err := d.Set("rules", flattenFirewallRules(firewall.Rules)); err != nil {
+		return err
+	}
+	if err := d.Set("created_at", firewall.CreatedAt); err != nil {
+		return err
+	}
+	if err := d.Set("updated_at", firewall.UpdatedAt); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/idcloudhost/resource_loadbalancer.go
+++ b/idcloudhost/resource_loadbalancer.go
@@ -1,0 +1,498 @@
+package idcloudhost
+
+import (
+	"context"
+	"fmt"
+
+	idcloudhostAPI "github.com/bapung/idcloudhost-go-client-library/idcloudhost/api"
+	idcloudhostLoadBalancer "github.com/bapung/idcloudhost-go-client-library/idcloudhost/loadbalancer"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceLoadBalancer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLoadBalancerCreate,
+		ReadContext:   resourceLoadBalancerRead,
+		UpdateContext: resourceLoadBalancerUpdate,
+		DeleteContext: resourceLoadBalancerDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"billing_account_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"network_uuid": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"reserve_public_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"targets": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"target_uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"target_ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"forwarding_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"target_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"private_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	request := &idcloudhostLoadBalancer.CreateLoadBalancerRequest{
+		DisplayName:      d.Get("display_name").(string),
+		BillingAccountID: d.Get("billing_account_id").(int),
+		NetworkUUID:      d.Get("network_uuid").(string),
+		ReservePublicIP:  d.Get("reserve_public_ip").(bool),
+	}
+
+	// Add targets if provided
+	if v, ok := d.GetOk("targets"); ok {
+		request.Targets = expandLoadBalancerTargets(v.([]interface{}))
+	}
+
+	// Add forwarding rules if provided
+	if v, ok := d.GetOk("forwarding_rules"); ok {
+		request.Rules = expandLoadBalancerRules(v.([]interface{}))
+	}
+
+	lbApi := c.LoadBalancer
+	if err := lbApi.CreateLoadBalancer(request); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create load balancer",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId(lbApi.LoadBalancer.UUID)
+
+	resourceLoadBalancerRead(ctx, d, m)
+
+	return diags
+}
+
+func resourceLoadBalancerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	lbApi := c.LoadBalancer
+	if err := lbApi.GetLoadBalancer(uuid); err != nil {
+		// If load balancer not found, remove from state
+		d.SetId("")
+		return diags
+	}
+
+	if err := setLoadBalancerResource(d, lbApi.LoadBalancer); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to set load balancer resource",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	return diags
+}
+
+func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+	lbApi := c.LoadBalancer
+
+	// Update display name
+	if d.HasChange("display_name") {
+		displayName := d.Get("display_name").(string)
+		if err := lbApi.RenameLoadBalancer(uuid, displayName); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to rename load balancer",
+				Detail:   fmt.Sprint(err),
+			})
+			return diags
+		}
+	}
+
+	// Update billing account
+	if d.HasChange("billing_account_id") {
+		billingAccountID := d.Get("billing_account_id").(int)
+		if err := lbApi.ChangeBillingAccount(uuid, billingAccountID); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to change billing account",
+				Detail:   fmt.Sprint(err),
+			})
+			return diags
+		}
+	}
+
+	// Handle targets changes
+	if d.HasChange("targets") {
+		old, new := d.GetChange("targets")
+		oldTargets := expandLoadBalancerTargets(old.([]interface{}))
+		newTargets := expandLoadBalancerTargets(new.([]interface{}))
+
+		// Get current state to have target UUIDs
+		if err := lbApi.GetLoadBalancer(uuid); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to get load balancer state",
+				Detail:   fmt.Sprint(err),
+			})
+			return diags
+		}
+
+		// Build a map of existing targets by their UUID
+		existingTargetsMap := make(map[string]idcloudhostLoadBalancer.Target)
+		for _, target := range lbApi.LoadBalancer.Targets {
+			key := fmt.Sprintf("%s-%s", target.TargetType, target.TargetUUID)
+			existingTargetsMap[key] = target
+		}
+
+		// Build maps for comparison
+		oldMap := make(map[string]bool)
+		newMap := make(map[string]bool)
+
+		for _, t := range oldTargets {
+			key := fmt.Sprintf("%s-%s", t.TargetType, t.TargetUUID)
+			oldMap[key] = true
+		}
+
+		for _, t := range newTargets {
+			key := fmt.Sprintf("%s-%s", t.TargetType, t.TargetUUID)
+			newMap[key] = true
+		}
+
+		// Remove targets that are in old but not in new
+		for key := range oldMap {
+			if !newMap[key] {
+				if target, exists := existingTargetsMap[key]; exists {
+					if err := lbApi.RemoveTarget(uuid, target.TargetUUID); err != nil {
+						diags = append(diags, diag.Diagnostic{
+							Severity: diag.Warning,
+							Summary:  "Unable to remove target",
+							Detail:   fmt.Sprint(err),
+						})
+					}
+				}
+			}
+		}
+
+		// Add targets that are in new but not in old
+		for key := range newMap {
+			if !oldMap[key] {
+				// Find the target in newTargets
+				for _, t := range newTargets {
+					targetKey := fmt.Sprintf("%s-%s", t.TargetType, t.TargetUUID)
+					if targetKey == key {
+						if err := lbApi.AddTarget(uuid, &t); err != nil {
+							diags = append(diags, diag.Diagnostic{
+								Severity: diag.Error,
+								Summary:  "Unable to add target",
+								Detail:   fmt.Sprint(err),
+							})
+							return diags
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Handle forwarding rules changes
+	if d.HasChange("forwarding_rules") {
+		old, new := d.GetChange("forwarding_rules")
+		oldRules := expandLoadBalancerRules(old.([]interface{}))
+		newRules := expandLoadBalancerRules(new.([]interface{}))
+
+		// Get current state to have rule UUIDs
+		if err := lbApi.GetLoadBalancer(uuid); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to get load balancer state",
+				Detail:   fmt.Sprint(err),
+			})
+			return diags
+		}
+
+		// Build a map of existing rules by their ports
+		existingRulesMap := make(map[string]idcloudhostLoadBalancer.ForwardingRule)
+		for _, rule := range lbApi.LoadBalancer.ForwardingRules {
+			key := fmt.Sprintf("%d-%d", rule.SourcePort, rule.TargetPort)
+			existingRulesMap[key] = rule
+		}
+
+		// Build maps for comparison
+		oldMap := make(map[string]bool)
+		newMap := make(map[string]bool)
+
+		for _, r := range oldRules {
+			key := fmt.Sprintf("%d-%d", r.SourcePort, r.TargetPort)
+			oldMap[key] = true
+		}
+
+		for _, r := range newRules {
+			key := fmt.Sprintf("%d-%d", r.SourcePort, r.TargetPort)
+			newMap[key] = true
+		}
+
+		// Remove rules that are in old but not in new
+		for key := range oldMap {
+			if !newMap[key] {
+				if rule, exists := existingRulesMap[key]; exists {
+					if err := lbApi.RemoveRule(uuid, rule.UUID); err != nil {
+						diags = append(diags, diag.Diagnostic{
+							Severity: diag.Warning,
+							Summary:  "Unable to remove forwarding rule",
+							Detail:   fmt.Sprint(err),
+						})
+					}
+				}
+			}
+		}
+
+		// Add rules that are in new but not in old
+		for key := range newMap {
+			if !oldMap[key] {
+				// Find the rule in newRules
+				for _, r := range newRules {
+					ruleKey := fmt.Sprintf("%d-%d", r.SourcePort, r.TargetPort)
+					if ruleKey == key {
+						if err := lbApi.AddRule(uuid, &r); err != nil {
+							diags = append(diags, diag.Diagnostic{
+								Severity: diag.Error,
+								Summary:  "Unable to add forwarding rule",
+								Detail:   fmt.Sprint(err),
+							})
+							return diags
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return resourceLoadBalancerRead(ctx, d, m)
+}
+
+func resourceLoadBalancerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	lbApi := c.LoadBalancer
+	if err := lbApi.DeleteLoadBalancer(uuid); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to delete load balancer",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId("")
+
+	return diags
+}
+
+func expandLoadBalancerTargets(targets []interface{}) []idcloudhostLoadBalancer.CreateTargetRequest {
+	if len(targets) == 0 {
+		return []idcloudhostLoadBalancer.CreateTargetRequest{}
+	}
+
+	expandedTargets := make([]idcloudhostLoadBalancer.CreateTargetRequest, len(targets))
+
+	for i, target := range targets {
+		targetMap := target.(map[string]interface{})
+
+		expandedTargets[i] = idcloudhostLoadBalancer.CreateTargetRequest{
+			TargetType: targetMap["target_type"].(string),
+			TargetUUID: targetMap["target_uuid"].(string),
+		}
+	}
+
+	return expandedTargets
+}
+
+func expandLoadBalancerRules(rules []interface{}) []idcloudhostLoadBalancer.CreateRuleRequest {
+	if len(rules) == 0 {
+		return []idcloudhostLoadBalancer.CreateRuleRequest{}
+	}
+
+	expandedRules := make([]idcloudhostLoadBalancer.CreateRuleRequest, len(rules))
+
+	for i, rule := range rules {
+		ruleMap := rule.(map[string]interface{})
+
+		expandedRules[i] = idcloudhostLoadBalancer.CreateRuleRequest{
+			SourcePort: ruleMap["source_port"].(int),
+			TargetPort: ruleMap["target_port"].(int),
+		}
+	}
+
+	return expandedRules
+}
+
+func flattenLoadBalancerTargets(targets []idcloudhostLoadBalancer.Target) []interface{} {
+	if len(targets) == 0 {
+		return []interface{}{}
+	}
+
+	flattenedTargets := make([]interface{}, len(targets))
+
+	for i, target := range targets {
+		targetMap := map[string]interface{}{
+			"target_type":       target.TargetType,
+			"target_uuid":       target.TargetUUID,
+			"target_ip_address": target.TargetIPAddress,
+			"created_at":        target.CreatedAt,
+		}
+		flattenedTargets[i] = targetMap
+	}
+
+	return flattenedTargets
+}
+
+func flattenLoadBalancerRules(rules []idcloudhostLoadBalancer.ForwardingRule) []interface{} {
+	if len(rules) == 0 {
+		return []interface{}{}
+	}
+
+	flattenedRules := make([]interface{}, len(rules))
+
+	for i, rule := range rules {
+		ruleMap := map[string]interface{}{
+			"source_port": rule.SourcePort,
+			"target_port": rule.TargetPort,
+			"protocol":    rule.Protocol,
+			"uuid":        rule.UUID,
+			"created_at":  rule.CreatedAt,
+		}
+		flattenedRules[i] = ruleMap
+	}
+
+	return flattenedRules
+}
+
+func setLoadBalancerResource(d *schema.ResourceData, lb *idcloudhostLoadBalancer.LoadBalancer) error {
+	if err := d.Set("uuid", lb.UUID); err != nil {
+		return err
+	}
+	if err := d.Set("display_name", lb.DisplayName); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", lb.UserID); err != nil {
+		return err
+	}
+	if err := d.Set("billing_account_id", lb.BillingAccountID); err != nil {
+		return err
+	}
+	if err := d.Set("network_uuid", lb.NetworkUUID); err != nil {
+		return err
+	}
+	if err := d.Set("private_address", lb.PrivateAddress); err != nil {
+		return err
+	}
+	if err := d.Set("targets", flattenLoadBalancerTargets(lb.Targets)); err != nil {
+		return err
+	}
+	if err := d.Set("forwarding_rules", flattenLoadBalancerRules(lb.ForwardingRules)); err != nil {
+		return err
+	}
+	if err := d.Set("created_at", lb.CreatedAt); err != nil {
+		return err
+	}
+	if err := d.Set("updated_at", lb.UpdatedAt); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/idcloudhost/resource_network.go
+++ b/idcloudhost/resource_network.go
@@ -1,0 +1,206 @@
+package idcloudhost
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	idcloudhostAPI "github.com/bapung/idcloudhost-go-client-library/idcloudhost/api"
+	idcloudhostNetwork "github.com/bapung/idcloudhost-go-client-library/idcloudhost/network"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceNetwork() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNetworkCreate,
+		ReadContext:   resourceNetworkRead,
+		UpdateContext: resourceNetworkUpdate,
+		DeleteContext: resourceNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	name := d.Get("name").(string)
+
+	networkApi := c.Network
+	if err := networkApi.CreateNetwork(name); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create network",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId(networkApi.Network.UUID)
+
+	// Set as default if requested
+	if d.Get("default").(bool) {
+		if err := networkApi.SetAsDefault(networkApi.Network.UUID); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Unable to set network as default",
+				Detail:   fmt.Sprint(err),
+			})
+		}
+	}
+
+	resourceNetworkRead(ctx, d, m)
+
+	return diags
+}
+
+func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	networkApi := c.Network
+	if err := networkApi.GetNetwork(uuid); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to get network",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	if err := setNetworkResource(d, networkApi.Network); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to set network resource",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	return diags
+}
+
+func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+	networkApi := c.Network
+
+	if d.HasChange("name") {
+		name := d.Get("name").(string)
+		if err := networkApi.UpdateNetwork(uuid, name); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to update network",
+				Detail:   fmt.Sprint(err),
+			})
+			return diags
+		}
+	}
+
+	if d.HasChange("default") {
+		if d.Get("default").(bool) {
+			if err := networkApi.SetAsDefault(uuid); err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Unable to set network as default",
+					Detail:   fmt.Sprint(err),
+				})
+				return diags
+			}
+		}
+	}
+
+	return resourceNetworkRead(ctx, d, m)
+}
+
+func resourceNetworkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	uuid := d.Id()
+
+	networkApi := c.Network
+	if err := networkApi.DeleteNetwork(uuid); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to delete network",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId("")
+
+	return diags
+}
+
+func setNetworkResource(d *schema.ResourceData, network *idcloudhostNetwork.Network) error {
+	if err := d.Set("id", strconv.Itoa(network.ID)); err != nil {
+		return err
+	}
+	if err := d.Set("name", network.Name); err != nil {
+		return err
+	}
+	if err := d.Set("uuid", network.UUID); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", network.UserID); err != nil {
+		return err
+	}
+	if err := d.Set("default", network.Default); err != nil {
+		return err
+	}
+	if err := d.Set("description", network.Description); err != nil {
+		return err
+	}
+	if err := d.Set("created_at", network.CreatedAt); err != nil {
+		return err
+	}
+	if err := d.Set("updated_at", network.UpdatedAt); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/idcloudhost/resource_objectstorage.go
+++ b/idcloudhost/resource_objectstorage.go
@@ -1,0 +1,188 @@
+package idcloudhost
+
+import (
+	"context"
+	"fmt"
+
+	idcloudhostAPI "github.com/bapung/idcloudhost-go-client-library/idcloudhost/api"
+	idcloudhostObjectStorage "github.com/bapung/idcloudhost-go-client-library/idcloudhost/objectstorage"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceObjectStorage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceObjectStorageCreate,
+		ReadContext:   resourceObjectStorageRead,
+		DeleteContext: resourceObjectStorageDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"billing_account_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"size_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"num_objects": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_suspended": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"acl": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceObjectStorageCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	name := d.Get("name").(string)
+	billingAccountID := d.Get("billing_account_id").(int)
+
+	osApi := c.ObjectStorage
+	if err := osApi.CreateBucket(name, billingAccountID); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create object storage bucket",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId(osApi.Bucket.Name)
+
+	resourceObjectStorageRead(ctx, d, m)
+
+	return diags
+}
+
+func resourceObjectStorageRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	name := d.Id()
+
+	osApi := c.ObjectStorage
+	if err := osApi.ListBuckets(); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to list buckets",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	// Find the bucket with matching name
+	var foundBucket *idcloudhostObjectStorage.Bucket
+	for _, bucket := range osApi.Buckets {
+		if bucket.Name == name {
+			foundBucket = &bucket
+			break
+		}
+	}
+
+	if foundBucket == nil {
+		d.SetId("")
+		return diags
+	}
+
+	if err := setObjectStorageResource(d, foundBucket); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to set object storage resource",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	return diags
+}
+
+func resourceObjectStorageDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*idcloudhostAPI.APIClient)
+	var diags diag.Diagnostics
+
+	name := d.Id()
+
+	osApi := c.ObjectStorage
+	if err := osApi.DeleteBucket(name); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to delete object storage bucket",
+			Detail:   fmt.Sprint(err),
+		})
+		return diags
+	}
+
+	d.SetId("")
+
+	return diags
+}
+
+func setObjectStorageResource(d *schema.ResourceData, bucket *idcloudhostObjectStorage.Bucket) error {
+	if err := d.Set("name", bucket.Name); err != nil {
+		return err
+	}
+	if err := d.Set("billing_account_id", bucket.BillingAccount); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", bucket.UserID); err != nil {
+		return err
+	}
+	if err := d.Set("size_bytes", bucket.SizeBytes); err != nil {
+		return err
+	}
+	if err := d.Set("num_objects", bucket.NumObjects); err != nil {
+		return err
+	}
+	if err := d.Set("owner", bucket.Owner); err != nil {
+		return err
+	}
+	if err := d.Set("is_suspended", bucket.IsSuspended); err != nil {
+		return err
+	}
+	if err := d.Set("acl", bucket.ACL); err != nil {
+		return err
+	}
+	if err := d.Set("created_at", bucket.CreatedAt); err != nil {
+		return err
+	}
+	if err := d.Set("modified_at", bucket.ModifiedAt); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request adds comprehensive example Terraform configurations demonstrating how to use the `idcloudhost` provider to manage various cloud resources, and registers new resource types within the provider. It also updates the Go client library dependency to the latest version and cleans up indirect dependencies.

**New Example Configurations:**

* General infrastructure example:
  - Adds `examples/complete/main.tf`, showcasing a full stack deployment including networks, firewalls, VMs, load balancers, object storage, and floating IPs, with outputs for key resource attributes.
* Resource-specific examples:
  - Adds `examples/firewall/main.tf` for firewall resources, `examples/loadbalancer/main.tf` for load balancer resources, `examples/network/main.tf` for network resources, and `examples/objectstorage/main.tf` for object storage resources, each illustrating resource creation and outputs. [[1]](diffhunk://#diff-91d698143a6ed6a3dd66329e8246873c4d7ccfd5f4a4a6d9e08e819b294d04bdR1-R116) [[2]](diffhunk://#diff-7953947916746b640a5765b017cf7fd88fd141f12d0856d2b613be60ce06ab70R1-R110) [[3]](diffhunk://#diff-047e9a6fd9f97a628bbb2e1ddc71644f8ce43a4548d6ab3a609630fd3b6e371fR1-R41) [[4]](diffhunk://#diff-2548ca8b033c8db04d1dfe88e7b162a9ba26f25a9d62fe6e085a07f863a23128R1-R62)

**Provider Enhancements:**

* Registers new resource types (`idcloudhost_network`, `idcloudhost_firewall`, `idcloudhost_loadbalancer`, `idcloudhost_objectstorage`) in the provider's resource map, enabling Terraform to manage these resources.

**Dependency Updates:**

* Updates the `idcloudhost-go-client-library` dependency from `v1.0.5` to `v1.1.0` to ensure compatibility with new features and resources.
* Removes an unused indirect dependency (`github.com/stretchr/testify`) from `go.mod` for cleanup.